### PR TITLE
Fix patch result regression introduced with #116

### DIFF
--- a/src/repositories/lib/mongo.js
+++ b/src/repositories/lib/mongo.js
@@ -76,7 +76,7 @@ module.exports = ({collection, createModel, createPaginatedList = paginatedListF
       const result = await collection.findOneAndUpdate(
         query,
         {$set: updateData},
-        {returnOriginal: false}
+        {returnDocument: 'after'}
       );
 
       return result.value ? createModel(result.value) : null;


### PR DESCRIPTION
Return the updated model instead of the original.

The new option was introduced in mongodb^4.2