### PR TITLE
Use "new" node docker image properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL \
   Vendor="RealMQ GmbH" \
   Version="0.1.1"
 
-WORKDIR /usr/src/app
+WORKDIR /home/node/app
 
 COPY package.json package-lock.json ./
 RUN npm install
@@ -16,4 +16,3 @@ COPY . .
 CMD ["npm", "start"]
 
 EXPOSE 8080
-USER www-data


### PR DESCRIPTION
The ancient docker image used before had a different user and directory structure then the "new" node:16 image we switched recently (#115), which caused file access issues. This change addresses that by using the default "node" user and placing the code into their home folder.