### PR TITLE
Allow for multiple connections per auth token

### DIFF
--- a/src/api/client/v1/mappers/user.js
+++ b/src/api/client/v1/mappers/user.js
@@ -15,6 +15,7 @@ module.exports = entity => mapGeneric({
   entity,
   propertyMap: {
     id: 'id',
+    isOnline: 'isOnline',
     properties: 'properties',
     createdAt: 'createdAt',
     updatedAt: 'updatedAt',

--- a/src/bootstrap/database.js
+++ b/src/bootstrap/database.js
@@ -28,6 +28,12 @@ module.exports = async ({config, logger}) => {
       realmAwareIdxSpec,
       {key: {realmId: 1, channelId: 1, createdAt: 1}, name: 'realmId_channelId_createdAt'},
     ]),
+    db.collection('realtime-connections').createIndexes([
+      realmAwareIdxSpec,
+      {key: {realmId: 1, tokenId: 1}, name: 'realmId_tokenId'},
+      {key: {realmId: 1, userId: 1}, name: 'realmId_userId'},
+      {key: {clientId: 1}, name: 'clientId', unique: true},
+    ]),
     db.collection('subscriptions').createIndexes([
       realmAwareIdxSpec,
       {key: {realmId: 1, userId: 1, channelId: 1}, name: 'realmId_userId_channelId', unique: true},

--- a/src/bootstrap/database.js
+++ b/src/bootstrap/database.js
@@ -30,7 +30,7 @@ module.exports = async ({config, logger}) => {
     ]),
     db.collection('realtime-connections').createIndexes([
       realmAwareIdxSpec,
-      {key: {realmId: 1, tokenId: 1}, name: 'realmId_tokenId'},
+      {key: {realmId: 1, authId: 1}, name: 'realmId_authId'},
       {key: {realmId: 1, userId: 1}, name: 'realmId_userId'},
       {key: {clientId: 1}, name: 'clientId', unique: true},
     ]),

--- a/src/bootstrap/repositories.js
+++ b/src/bootstrap/repositories.js
@@ -12,6 +12,7 @@ module.exports = async ({db}) => {
     channelCollection,
     messageCollection,
     realmCollection,
+    realtimeConnectionCollection,
     subscriptionCollection,
     userCollection,
   ] = await Promise.all([
@@ -19,6 +20,7 @@ module.exports = async ({db}) => {
     db.collection('channels'),
     db.collection('messages'),
     db.collection('realms'),
+    db.collection('realtime-connections'),
     db.collection('subscriptions'),
     db.collection('users'),
   ]);
@@ -27,6 +29,7 @@ module.exports = async ({db}) => {
     channelCollection,
     messageCollection,
     realmCollection,
+    realtimeConnectionCollection,
     subscriptionCollection,
     userCollection,
   });

--- a/src/bootstrap/tasks.js
+++ b/src/bootstrap/tasks.js
@@ -56,6 +56,7 @@ module.exports = ({
       channelRepository,
       messageRepository,
       userRepository,
+      realtimeConnectionRepository,
       subscriptionRepository,
       sendSubscriptionSyncMessage,
     }),

--- a/src/bootstrap/tasks.js
+++ b/src/bootstrap/tasks.js
@@ -49,6 +49,7 @@ module.exports = ({
       subscriptionRepository,
       realtimeConnectionRepository,
       messageRepository,
+      userRepository
     }),
     client: initClientTasks({
       authTokenRules,

--- a/src/bootstrap/tasks.js
+++ b/src/bootstrap/tasks.js
@@ -12,6 +12,7 @@ const initCommonTasks = require('../tasks/common');
  * @param {ChannelRepository} channelRepository Channel repository
  * @param {MessageRepository} messageRepository Message repository
  * @param {RealmRepository} realmRepository Realm repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository Realtime connection repository
  * @param {SubscriptionRepository} subscriptionRepository Subscription repository
  * @param {UserRepository} userRepository User repository
  * @returns {{broker: BrokerTasks, admin: AdminTasks, client: ClientTasks}} Tasks
@@ -24,6 +25,7 @@ module.exports = ({
     channel: channelRepository,
     message: messageRepository,
     realm: realmRepository,
+    realtimeConnection: realtimeConnectionRepository,
     subscription: subscriptionRepository,
     user: userRepository,
   },
@@ -45,6 +47,7 @@ module.exports = ({
       authRepository,
       channelRepository,
       subscriptionRepository,
+      realtimeConnectionRepository,
       messageRepository,
     }),
     client: initClientTasks({

--- a/src/lib/test/mocks/repositories/auth.js
+++ b/src/lib/test/mocks/repositories/auth.js
@@ -82,4 +82,5 @@ module.exports = {
   async deleteOne() {},
   async findOneAndDelete() {},
   async deleteAllByUserId() {},
+  async setIsOnline() {}
 };

--- a/src/lib/test/mocks/repositories/auth.js
+++ b/src/lib/test/mocks/repositories/auth.js
@@ -79,7 +79,7 @@ module.exports = {
       ...properties,
     };
   },
-
+  async deleteOne() {},
   async findOneAndDelete() {},
   async deleteAllByUserId() {},
 };

--- a/src/lib/test/mocks/repositories/realtime-connection.js
+++ b/src/lib/test/mocks/repositories/realtime-connection.js
@@ -52,6 +52,7 @@ module.exports = {
     });
   },
 
-  deleteMany() {},
+  deleteAllByUserId() {},
+  deleteAllByAuthId() {},
   deleteOneByClientId() {},
 };

--- a/src/lib/test/mocks/repositories/realtime-connection.js
+++ b/src/lib/test/mocks/repositories/realtime-connection.js
@@ -1,0 +1,57 @@
+const authRepository = require('./auth');
+const realtimeConnectionModel = require('../../../../models/realtime-connection');
+const {duplicate: duplicateError} = require('../../../../repositories/lib/error');
+
+const knownRealtimeConnectionId = 'known-realtime-connection-id';
+const unknownRealtimeConnectionId = 'unknown-realtime-connection-id';
+const knownRealmId = 'known-realm-id';
+const unknownRealmId = 'unknown-realm-id';
+const knownUserId = 'known-user-id';
+const unknownUserId = 'unknown-user-id';
+const knownClientId = `${authRepository.knownToken}:post-fix`;
+const unknownClientId = `${authRepository.unknownToken}:post-fix`;
+const duplicateClientId = `${authRepository.duplicateToken}:post-fix`;
+
+const validRealtimeConnection = realtimeConnectionModel({
+  id: knownRealtimeConnectionId,
+  realmId: knownRealmId,
+  userId: knownUserId,
+  authId: authRepository.knownAuthId,
+  clientId: knownClientId,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+module.exports = {
+  knownRealtimeConnectionId,
+  unknownRealtimeConnectionId,
+  knownAuthId: authRepository.knownAuthId,
+  unknownAuthId: authRepository.unknownAuthId,
+  knownRealmId,
+  unknownRealmId,
+  knownUserId,
+  unknownUserId,
+  knownClientId,
+  unknownClientId,
+  duplicateClientId,
+  validRealtimeConnection,
+
+  async create({realmId, id, authId, clientId, userId}) {
+    if (clientId === duplicateClientId) {
+      throw duplicateError();
+    }
+
+    return realtimeConnectionModel({
+      id: id || knownRealtimeConnectionId,
+      realmId,
+      userId,
+      authId,
+      clientId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  },
+
+  deleteMany() {},
+  deleteOneByClientId() {},
+};

--- a/src/lib/test/mocks/repositories/realtime-connection.js
+++ b/src/lib/test/mocks/repositories/realtime-connection.js
@@ -54,5 +54,5 @@ module.exports = {
 
   deleteAllByUserId() {},
   deleteAllByAuthId() {},
-  deleteOneByClientId() {},
+  findOneAndDeleteByClientId() {},
 };

--- a/src/lib/test/mocks/repositories/user.js
+++ b/src/lib/test/mocks/repositories/user.js
@@ -83,4 +83,6 @@ module.exports = {
   },
 
   async findOneAndDelete() {},
+
+  async setIsOnline() {}
 };

--- a/src/models/realtime-connection.js
+++ b/src/models/realtime-connection.js
@@ -5,7 +5,7 @@ const stripUndefined = require('../lib/strip-undefined');
  * @param {string} id
  * @param {string} realmId
  * @param {string} userId
- * @param {string} tokenId
+ * @param {string} authId
  * @param {string} clientId
  * @param {Date} [createdAt]
  * @param {Date} [updatedAt]
@@ -18,7 +18,7 @@ module.exports = ({
   id,
   realmId,
   userId,
-  tokenId,
+  authId,
   clientId,
   createdAt,
   updatedAt,
@@ -26,7 +26,7 @@ module.exports = ({
   id,
   realmId,
   userId,
-  tokenId,
+  authId,
   clientId,
   createdAt,
   updatedAt,

--- a/src/models/realtime-connection.js
+++ b/src/models/realtime-connection.js
@@ -1,0 +1,33 @@
+const stripUndefined = require('../lib/strip-undefined');
+
+/**
+ * @class RealtimeConnection
+ * @param {string} id
+ * @param {string} realmId
+ * @param {string} userId
+ * @param {string} tokenId
+ * @param {string} clientId
+ * @param {Date} [createdAt]
+ * @param {Date} [updatedAt]
+ */
+
+/**
+ * @return {RealtimeConnection} The generalized realtime connection model
+ */
+module.exports = ({
+  id,
+  realmId,
+  userId,
+  tokenId,
+  clientId,
+  createdAt,
+  updatedAt,
+}) => stripUndefined({
+  id,
+  realmId,
+  userId,
+  tokenId,
+  clientId,
+  createdAt,
+  updatedAt,
+});

--- a/src/repositories/auth.js
+++ b/src/repositories/auth.js
@@ -42,6 +42,21 @@ module.exports = ({collection, createModel = createAuthModel}) => {
 
       await multiRealmRepository.deleteMany({realmId, userId});
     },
+
+    /**
+     * Set isOnline status of the given auth record.
+     * @param {string} realmId
+     * @param {string} id
+     * @param {boolean} isOnline
+     * @returns {Promise<void>}
+     */
+    async setIsOnline({realmId, id, isOnline}) {
+      if (!id) {
+        throw new Error('Missing id');
+      }
+
+      await multiRealmRepository.update({realmId, id, isOnline})
+    }
   };
 };
 

--- a/src/repositories/index.js
+++ b/src/repositories/index.js
@@ -2,6 +2,7 @@ const createAuthRepository = require('./auth');
 const createChannelRepository = require('./channel');
 const createMessageRepository = require('./message');
 const createRealmRepository = require('./realm');
+const createRealtimeConnectionRepository = require('./realtime-connection');
 const createSubscriptionRepository = require('./subscription');
 const createUserRepository = require('./user');
 
@@ -12,6 +13,7 @@ const createUserRepository = require('./user');
  * @param {Collection} channelCollection Dependency
  * @param {Collection} messageCollection Dependency
  * @param {Collection} realmCollection Dependency
+ * @param {Collection} realtimeConnectionCollection Dependency
  * @param {Collection} subscriptionCollection Dependency
  * @param {Collection} userCollection Dependency
  * @return {Repositories} The repositories
@@ -19,6 +21,7 @@ const createUserRepository = require('./user');
 module.exports = ({
   authCollection, channelCollection, messageCollection,
   realmCollection, subscriptionCollection, userCollection,
+  realtimeConnectionCollection
 }) =>
   /**
    * @typedef {object} Repositories
@@ -26,6 +29,7 @@ module.exports = ({
    * @property {ChannelRepository} channel
    * @property {MessageRepository} message
    * @property {RealmRepository} realm
+   * @property {RealtimeConnectionRepository} realtimeConnection
    * @property {SubscriptionRepository} subscription
    * @property {UserRepository} user
    */
@@ -34,6 +38,7 @@ module.exports = ({
     channel: createChannelRepository({collection: channelCollection}),
     message: createMessageRepository({collection: messageCollection}),
     realm: createRealmRepository({collection: realmCollection}),
+    realtimeConnection: createRealtimeConnectionRepository({collection: realtimeConnectionCollection}),
     subscription: createSubscriptionRepository({collection: subscriptionCollection}),
     user: createUserRepository({collection: userCollection}),
   });

--- a/src/repositories/lib/mongo-multi-realm.js
+++ b/src/repositories/lib/mongo-multi-realm.js
@@ -37,6 +37,15 @@ module.exports = ({collection, createModel, generateId}) => {
     /**
      * @inheritDoc
      */
+    count: async query => {
+      assertRealmId(query.realmId);
+
+      return mongoRepo.count(query);
+    },
+
+    /**
+     * @inheritDoc
+     */
     deleteMany: async query => {
       assertRealmId(query.realmId);
 

--- a/src/repositories/lib/mongo.js
+++ b/src/repositories/lib/mongo.js
@@ -42,6 +42,13 @@ module.exports = ({collection, createModel, createPaginatedList = paginatedListF
     deleteMany: query => collection.deleteMany(query),
 
     /**
+     * Delete one document from a collection that matches the query.
+     * @param {object} query Record filter
+     * @return {Promise} Promised result
+     */
+    deleteOne: query => collection.deleteOne(query),
+
+    /**
      * Find one record that matches the query.
      * @param {object} query Record filter
      * @return {Promise<object>} Promised model

--- a/src/repositories/lib/mongo.js
+++ b/src/repositories/lib/mongo.js
@@ -35,6 +35,13 @@ module.exports = ({collection, createModel, createPaginatedList = paginatedListF
     },
 
     /**
+     * Count documents that match the given query
+     * @param {object} query
+     * @returns {Promise<number>}
+     */
+    count: query => collection.countDocuments(query),
+
+    /**
      * Delete all documents within a collection that match the query.
      * @param {object} query Record filter
      * @return {Promise} Promised result

--- a/src/repositories/realtime-connection.js
+++ b/src/repositories/realtime-connection.js
@@ -21,5 +21,27 @@ module.exports = ({collection, createModel = createRealtimeConnectionModel}) => 
     async deleteOneByClientId(clientId) {
       return multiRealmRepo.mongoRepo.deleteOne({clientId});
     },
+
+    /**
+     * Delete all realtime connections for a given auth id in a realm.
+     *
+     * @param {string} realmId
+     * @param {string} authId
+     * @returns {Promise<void>}
+     */
+    async deleteAllByAuthId({realmId, authId}) {
+      return multiRealmRepo.deleteMany({realmId, authId});
+    },
+
+    /**
+     * Delete all realtime connections for the given user id in a realm.
+     *
+     * @param {string} realmId
+     * @param {string} userId
+     * @returns {Promise<void>}
+     */
+    async deleteAllByUserId({realmId, userId}) {
+      return multiRealmRepo.deleteMany({realmId, userId});
+    }
   };
 };

--- a/src/repositories/realtime-connection.js
+++ b/src/repositories/realtime-connection.js
@@ -1,0 +1,25 @@
+const createRealtimeConnectionModel = require('../models/realtime-connection');
+const createMongoMultiRealmRepository = require('./lib/mongo-multi-realm');
+
+/**
+ * Create realtime connection repository.
+ *
+ * @param {Collection} collection Mongodb repository
+ * @param {function} createModel Model factory
+ * @return {RealtimeConnectionRepository} The created realtime connection repository
+ */
+module.exports = ({collection, createModel = createRealtimeConnectionModel}) => {
+  const multiRealmRepo = createMongoMultiRealmRepository({collection, createModel});
+
+  /**
+   * @class RealtimeConnectionRepository
+   * @extends MongoMultiRealmRepository
+   */
+  return {
+    ...multiRealmRepo,
+
+    async deleteOneByClientId(clientId) {
+      return multiRealmRepo.mongoRepo.deleteOne({clientId});
+    },
+  };
+};

--- a/src/repositories/realtime-connection.js
+++ b/src/repositories/realtime-connection.js
@@ -18,8 +18,8 @@ module.exports = ({collection, createModel = createRealtimeConnectionModel}) => 
   return {
     ...multiRealmRepo,
 
-    async deleteOneByClientId(clientId) {
-      return multiRealmRepo.mongoRepo.deleteOne({clientId});
+    async findOneAndDeleteByClientId(clientId) {
+      return multiRealmRepo.mongoRepo.findOneAndDelete({clientId});
     },
 
     /**
@@ -41,7 +41,30 @@ module.exports = ({collection, createModel = createRealtimeConnectionModel}) => 
      * @returns {Promise<void>}
      */
     async deleteAllByUserId({realmId, userId}) {
+      if (!userId) {
+        throw new Error('Missing user id');
+      }
       return multiRealmRepo.deleteMany({realmId, userId});
+    },
+
+    /**
+     * Count the number of connections per user id in a realm.
+     * @param {string} realmId
+     * @param {string} userId
+     * @returns {Promise<number>}
+     */
+    async countByUserId({realmId, userId}) {
+      return multiRealmRepo.count({realmId, userId});
+    },
+
+    /**
+     * Count the number of connections per auth id in a realm.
+     * @param {string} realmId
+     * @param {string} authId
+     * @returns {Promise<number>}
+     */
+    async countByAuthId({realmId, authId}) {
+      return multiRealmRepo.count({realmId, authId});
     }
   };
 };

--- a/src/repositories/user.js
+++ b/src/repositories/user.js
@@ -38,5 +38,20 @@ module.exports = ({collection, createModel = createUserModel}) => {
 
       return user;
     },
+
+    /**
+     * Set isOnline status of the given user record.
+     * @param {string} realmId
+     * @param {string} id
+     * @param {boolean} isOnline
+     * @returns {Promise<void>}
+     */
+    async setIsOnline({realmId, id, isOnline}) {
+      if (!id) {
+        throw new Error('Missing id');
+      }
+
+      await multiRealmRepo.update({realmId, id, isOnline})
+    }
   };
 };

--- a/src/rules/parse-client-id.js
+++ b/src/rules/parse-client-id.js
@@ -1,0 +1,19 @@
+const SEPARATOR = ':';
+
+/**
+ * @param {string} clientId
+ * @returns {string}
+ */
+function parseClientId(clientId) {
+  if (!clientId) {
+    return clientId;
+  }
+
+  // consider everything BEFORE separator as token.
+  return clientId.split(SEPARATOR)[0];
+}
+
+
+module.exports = {
+  parseTokenFromClientId: parseClientId
+}

--- a/src/rules/parse-client-id.js
+++ b/src/rules/parse-client-id.js
@@ -4,7 +4,7 @@ const SEPARATOR = ':';
  * @param {string} clientId
  * @returns {string}
  */
-function parseClientId(clientId) {
+function extractTokenFromClientId(clientId) {
   if (!clientId) {
     return clientId;
   }
@@ -15,5 +15,5 @@ function parseClientId(clientId) {
 
 
 module.exports = {
-  parseTokenFromClientId: parseClientId
+  extractTokenFromClientId
 }

--- a/src/tasks/broker/authenticate-client.js
+++ b/src/tasks/broker/authenticate-client.js
@@ -1,3 +1,5 @@
+const {parseTokenFromClientId} = require('../../rules/parse-client-id');
+
 /**
  * @typedef {object} BrokerClient
  * @prop {string} id
@@ -23,7 +25,10 @@ module.exports = ({authRepository}) =>
       authenticated: false,
     };
 
-    const auth = await authRepository.findOneByToken(clientId);
+    // parse the actual token from clientId
+    const token = parseTokenFromClientId(clientId);
+
+    const auth = await authRepository.findOneByToken(token);
     if (auth) {
       Object.assign(client, {
         authenticated: true,

--- a/src/tasks/broker/authenticate-client.js
+++ b/src/tasks/broker/authenticate-client.js
@@ -1,4 +1,4 @@
-const {parseTokenFromClientId} = require('../../rules/parse-client-id');
+const {extractTokenFromClientId} = require('../../rules/parse-client-id');
 
 /**
  * @typedef {object} BrokerClient
@@ -26,7 +26,7 @@ module.exports = ({authRepository}) =>
     };
 
     // parse the actual token from clientId
-    const token = parseTokenFromClientId(clientId);
+    const token = extractTokenFromClientId(clientId);
 
     const auth = await authRepository.findOneByToken(token);
     if (auth) {

--- a/src/tasks/broker/index.js
+++ b/src/tasks/broker/index.js
@@ -18,10 +18,18 @@ const initRecordMessage = require('./record-message');
  * @param {AuthRepository} authRepository Auth repository
  * @param {ChannelRepository} channelRepository Channel repository
  * @param {MessageRepository} messageRepository Message repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository Subscription repository
  * @param {SubscriptionRepository} subscriptionRepository Subscription repository
  * @return {BrokerTasks} Initialized tasks
  */
-module.exports = ({logger, authRepository, channelRepository, messageRepository, subscriptionRepository}) => {
+module.exports = ({
+  logger,
+  authRepository,
+  channelRepository,
+  messageRepository,
+  realtimeConnectionRepository,
+  subscriptionRepository
+}) => {
   const lookupStaticPermissions = initLookupStaticPermissions();
   const loadTopicPermissions = initLoadTopicPermissions({
     channelRepository,
@@ -39,9 +47,9 @@ module.exports = ({logger, authRepository, channelRepository, messageRepository,
     authorizeSubscribe:
       initAuthorizeSubscribe({loadTopicPermissions, rewriteTopicToInternal}),
     markClientOffline:
-      initMarkClientOffline({authRepository}),
+      initMarkClientOffline({realtimeConnectionRepository}),
     markClientOnline:
-      initMarkClientOnline({authRepository}),
+      initMarkClientOnline({authRepository, realtimeConnectionRepository}),
     recordMessage:
       initRecordMessage({channelRepository, messageRepository, logger}),
   };

--- a/src/tasks/broker/index.js
+++ b/src/tasks/broker/index.js
@@ -20,6 +20,7 @@ const initRecordMessage = require('./record-message');
  * @param {MessageRepository} messageRepository Message repository
  * @param {RealtimeConnectionRepository} realtimeConnectionRepository Subscription repository
  * @param {SubscriptionRepository} subscriptionRepository Subscription repository
+ * @param {UserRepository} userRepository User repository
  * @return {BrokerTasks} Initialized tasks
  */
 module.exports = ({
@@ -27,6 +28,7 @@ module.exports = ({
   authRepository,
   channelRepository,
   messageRepository,
+  userRepository,
   realtimeConnectionRepository,
   subscriptionRepository
 }) => {
@@ -47,9 +49,13 @@ module.exports = ({
     authorizeSubscribe:
       initAuthorizeSubscribe({loadTopicPermissions, rewriteTopicToInternal}),
     markClientOffline:
-      initMarkClientOffline({realtimeConnectionRepository}),
+      initMarkClientOffline({realtimeConnectionRepository, authRepository, userRepository}),
     markClientOnline:
-      initMarkClientOnline({authRepository, realtimeConnectionRepository}),
+      initMarkClientOnline({
+        authRepository,
+        userRepository,
+        realtimeConnectionRepository
+      }),
     recordMessage:
       initRecordMessage({channelRepository, messageRepository, logger}),
   };

--- a/src/tasks/broker/mark-client-offline.js
+++ b/src/tasks/broker/mark-client-offline.js
@@ -1,13 +1,45 @@
 /**
  * @param {RealtimeConnectionRepository} realtimeConnectionRepository Realtime connection repository
+ * @param {AuthRepository} authRepository Auth repository
+ * @param {UserRepository} userRepository User repository
  * @returns {BrokerTasks#markClientOffline} Task
  */
-module.exports = ({realtimeConnectionRepository}) =>
+module.exports = ({
+  authRepository,
+  realtimeConnectionRepository,
+  userRepository
+}) =>
   /**
    * @typedef {Function} BrokerTasks#markClientOffline
    * @param {string} clientId
    * @return {Promise<void>}
    */
   async clientId => {
-    await realtimeConnectionRepository.deleteOneByClientId(clientId);
+    const realtimeConnection = await realtimeConnectionRepository.findOneAndDeleteByClientId(clientId);
+
+    if (realtimeConnection) {
+      const [connectionsByUser, connectionsByAuth] = await Promise.all([
+        realtimeConnectionRepository.countByUserId({
+          realmId: realtimeConnection.realmId,
+          userId: realtimeConnection.userId
+        }),
+        realtimeConnectionRepository.countByAuthId({
+          realmId: realtimeConnection.realmId,
+          authId: realtimeConnection.authId
+        }),
+      ]);
+
+      await Promise.all([
+        connectionsByUser === 0 ? userRepository.setIsOnline({
+          realmId: realtimeConnection.realmId,
+          id: realtimeConnection.userId,
+          isOnline: false
+        }) : null,
+        connectionsByAuth === 0 ? authRepository.setIsOnline({
+          realmId: realtimeConnection.realmId,
+          id: realtimeConnection.authId,
+          isOnline: false
+        }) : null
+      ]);
+    }
   };

--- a/src/tasks/broker/mark-client-offline.js
+++ b/src/tasks/broker/mark-client-offline.js
@@ -1,19 +1,13 @@
 /**
- * @param {AuthRepository} authRepository Auth repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository Realtime connection repository
  * @returns {BrokerTasks#markClientOffline} Task
  */
-module.exports = ({authRepository}) =>
+module.exports = ({realtimeConnectionRepository}) =>
   /**
    * @typedef {Function} BrokerTasks#markClientOffline
    * @param {string} clientId
    * @return {Promise<void>}
    */
   async clientId => {
-    const auth = await authRepository.findOneByToken(clientId);
-    if (!auth) {
-      return;
-    }
-
-    auth.isOnline = false;
-    await authRepository.update(auth);
+    await realtimeConnectionRepository.deleteOneByClientId(clientId);
   };

--- a/src/tasks/broker/mark-client-offline.spec.js
+++ b/src/tasks/broker/mark-client-offline.spec.js
@@ -1,11 +1,17 @@
+const authRepository = require('../../lib/test/mocks/repositories/auth');
 const realtimeConnectionRepository = require('../../lib/test/mocks/repositories/realtime-connection');
+const userRepository = require('../../lib/test/mocks/repositories/user');
 const initMarkClientOffline = require('./mark-client-offline');
 
 describe('The markClientOffline task', () => {
   let markClientOffline;
   beforeEach(() => {
-    realtimeConnectionRepository.deleteOneByClientId = jest.fn();
-    markClientOffline = initMarkClientOffline({realtimeConnectionRepository});
+    realtimeConnectionRepository.findOneAndDeleteByClientId = jest.fn();
+    markClientOffline = initMarkClientOffline({
+      realtimeConnectionRepository,
+      authRepository,
+      userRepository
+    });
   });
 
   describe('when called with unknown clientId', () => {
@@ -18,7 +24,7 @@ describe('The markClientOffline task', () => {
     it('should delete the connection for the given client id', async () => {
       await markClientOffline(realtimeConnectionRepository.knownClientId);
 
-      expect(realtimeConnectionRepository.deleteOneByClientId).toBeCalledWith(realtimeConnectionRepository.knownClientId);
+      expect(realtimeConnectionRepository.findOneAndDeleteByClientId).toBeCalledWith(realtimeConnectionRepository.knownClientId);
     });
   });
 });

--- a/src/tasks/broker/mark-client-offline.spec.js
+++ b/src/tasks/broker/mark-client-offline.spec.js
@@ -1,35 +1,24 @@
-const authRepository = require('../../lib/test/mocks/repositories/auth');
+const realtimeConnectionRepository = require('../../lib/test/mocks/repositories/realtime-connection');
 const initMarkClientOffline = require('./mark-client-offline');
 
 describe('The markClientOffline task', () => {
   let markClientOffline;
   beforeEach(() => {
-    markClientOffline = initMarkClientOffline({authRepository});
+    realtimeConnectionRepository.deleteOneByClientId = jest.fn();
+    markClientOffline = initMarkClientOffline({realtimeConnectionRepository});
   });
 
   describe('when called with unknown clientId', () => {
-    it('should fail gracefully and not return anything', async () => {
-      const auth = await markClientOffline(authRepository.unknownToken);
-
-      expect(auth).toBeUndefined();
+    it('should fail gracefully', async () => {
+      await markClientOffline(realtimeConnectionRepository.unknownClientId);
     });
   });
 
   describe('when called with valid parameters', () => {
-    it('should return with the auth having the presence updated', async () => {
-      const auth = {isOnline: true};
-      markClientOffline = initMarkClientOffline({
-        authRepository: {
-          ...authRepository,
-          findOneByToken() {
-            return auth;
-          },
-        },
-      });
+    it('should delete the connection for the given client id', async () => {
+      await markClientOffline(realtimeConnectionRepository.knownClientId);
 
-      await markClientOffline(authRepository.knownToken);
-
-      expect(auth.isOnline).toBe(false);
+      expect(realtimeConnectionRepository.deleteOneByClientId).toBeCalledWith(realtimeConnectionRepository.knownClientId);
     });
   });
 });

--- a/src/tasks/broker/mark-client-online.js
+++ b/src/tasks/broker/mark-client-online.js
@@ -22,7 +22,7 @@ module.exports = ({authRepository, realtimeConnectionRepository}) =>
       await realtimeConnectionRepository.create({
         realmId: auth.realmId,
         userId: auth.userId,
-        tokenId: auth.id,
+        authId: auth.id,
         clientId
       });
     } catch (error) {

--- a/src/tasks/broker/mark-client-online.js
+++ b/src/tasks/broker/mark-client-online.js
@@ -1,19 +1,34 @@
+const {parseTokenFromClientId} = require('../../rules/parse-client-id');
+
 /**
  * @param {AuthRepository} authRepository Auth repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository Realtime connection repository
  * @returns {BrokerTasks#markClientOnline} Task
  */
-module.exports = ({authRepository}) =>
+module.exports = ({authRepository, realtimeConnectionRepository}) =>
   /**
    * @typedef {Function} BrokerTasks#markClientOnline
    * @param {string} clientId
    * @return {Promise<void>}
    */
   async clientId => {
-    const auth = await authRepository.findOneByToken(clientId);
+    const token = parseTokenFromClientId(clientId)
+    const auth = await authRepository.findOneByToken(token);
     if (!auth) {
       return;
     }
 
-    auth.isOnline = true;
-    await authRepository.update(auth);
+    try {
+      await realtimeConnectionRepository.create({
+        realmId: auth.realmId,
+        userId: auth.userId,
+        tokenId: auth.id,
+        clientId
+      });
+    } catch (error) {
+      // ignore cases where we already have a connection for the given clientId
+      if (!error.isDuplicateKeyError) {
+        throw error;
+      }
+    }
   };

--- a/src/tasks/broker/mark-client-online.js
+++ b/src/tasks/broker/mark-client-online.js
@@ -1,4 +1,4 @@
-const {parseTokenFromClientId} = require('../../rules/parse-client-id');
+const {extractTokenFromClientId} = require('../../rules/parse-client-id');
 
 /**
  * @param {AuthRepository} authRepository Auth repository
@@ -17,7 +17,7 @@ module.exports = ({
    * @return {Promise<void>}
    */
   async clientId => {
-    const token = parseTokenFromClientId(clientId)
+    const token = extractTokenFromClientId(clientId)
     const auth = await authRepository.findOneByToken(token);
     if (!auth) {
       return;

--- a/src/tasks/broker/mark-client-online.spec.js
+++ b/src/tasks/broker/mark-client-online.spec.js
@@ -1,12 +1,19 @@
 const authRepository = require('../../lib/test/mocks/repositories/auth');
 const realtimeConnectionRepository = require('../../lib/test/mocks/repositories/realtime-connection');
+const userRepository = require('../../lib/test/mocks/repositories/user');
 const initMarkClientOnline = require('./mark-client-online');
 
 describe('The markClientOnline task', () => {
   let markClientOnline;
   beforeEach(() => {
+    authRepository.setIsOnline = jest.fn();
+    userRepository.setIsOnline = jest.fn();
     realtimeConnectionRepository.create = jest.fn();
-    markClientOnline = initMarkClientOnline({authRepository, realtimeConnectionRepository});
+    markClientOnline = initMarkClientOnline({
+      authRepository,
+      realtimeConnectionRepository,
+      userRepository,
+    });
   });
 
   describe('when called with unknown clientId', () => {
@@ -21,6 +28,16 @@ describe('The markClientOnline task', () => {
       await markClientOnline(realtimeConnectionRepository.knownClientId);
 
       expect(realtimeConnectionRepository.create).toHaveBeenCalled();
+      expect(authRepository.setIsOnline).toHaveBeenCalledWith({
+        realmId: realtimeConnectionRepository.knownRealmId,
+        id: realtimeConnectionRepository.knownAuthId,
+        isOnline: true
+      });
+      expect(userRepository.setIsOnline).toHaveBeenCalledWith({
+        realmId: realtimeConnectionRepository.knownRealmId,
+        id: realtimeConnectionRepository.knownUserId,
+        isOnline: true
+      });
     });
   });
 });

--- a/src/tasks/broker/mark-client-online.spec.js
+++ b/src/tasks/broker/mark-client-online.spec.js
@@ -1,35 +1,26 @@
 const authRepository = require('../../lib/test/mocks/repositories/auth');
+const realtimeConnectionRepository = require('../../lib/test/mocks/repositories/realtime-connection');
 const initMarkClientOnline = require('./mark-client-online');
 
 describe('The markClientOnline task', () => {
   let markClientOnline;
   beforeEach(() => {
-    markClientOnline = initMarkClientOnline({authRepository});
+    realtimeConnectionRepository.create = jest.fn();
+    markClientOnline = initMarkClientOnline({authRepository, realtimeConnectionRepository});
   });
 
   describe('when called with unknown clientId', () => {
-    it('should fail gracefully and not return anything', async () => {
-      const auth = await markClientOnline(authRepository.unknownToken);
-
-      expect(auth).toBeUndefined();
+    it('should fail gracefully', async () => {
+      await markClientOnline(realtimeConnectionRepository.unknownClientId);
+      expect(realtimeConnectionRepository.create).not.toHaveBeenCalled();
     });
   });
 
   describe('when called with valid parameters', () => {
-    it('should return with the auth having the presence updated', async () => {
-      const auth = {isOnline: false};
-      markClientOnline = initMarkClientOnline({
-        authRepository: {
-          ...authRepository,
-          findOneByToken() {
-            return auth;
-          },
-        },
-      });
+    it('should create a new realtime connection', async () => {
+      await markClientOnline(realtimeConnectionRepository.knownClientId);
 
-      await markClientOnline(authRepository.knownToken);
-
-      expect(auth.isOnline).toBe(true);
+      expect(realtimeConnectionRepository.create).toHaveBeenCalled();
     });
   });
 });

--- a/src/tasks/client/delete-auth.js
+++ b/src/tasks/client/delete-auth.js
@@ -8,9 +8,10 @@ const createLookupQuery = require('./auth/create-lookup-query');
 /**
  * Init delete auth task
  * @param {AuthRepository} authRepository Auth repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository Realtime connection repository
  * @returns {ClientTasks#deleteAuth} Delete auth task
  */
-module.exports = ({authRepository}) =>
+module.exports = ({authRepository, realtimeConnectionRepository}) =>
   /**
    * @function ClientTasks#deleteAuth
    * @param {AuthModel} authToken Authentication
@@ -33,6 +34,13 @@ module.exports = ({authRepository}) =>
       return failure(unknownAuthError());
     }
 
-    await authRepository.findOneAndDelete(query);
+    await Promise.all([
+      authRepository.deleteOne(query),
+      realtimeConnectionRepository.deleteMany({
+        realmId,
+        authId: authToDelete.id
+      })
+    ]);
+
     return success(authToDelete);
   };

--- a/src/tasks/client/delete-auth.js
+++ b/src/tasks/client/delete-auth.js
@@ -36,7 +36,7 @@ module.exports = ({authRepository, realtimeConnectionRepository}) =>
 
     await Promise.all([
       authRepository.deleteOne(query),
-      realtimeConnectionRepository.deleteMany({
+      realtimeConnectionRepository.deleteAllByAuthId({
         realmId,
         authId: id
       })

--- a/src/tasks/client/delete-auth.js
+++ b/src/tasks/client/delete-auth.js
@@ -23,7 +23,7 @@ module.exports = ({authRepository, realtimeConnectionRepository}) =>
 
     if (scope !== 'admin') {
       return failure(errorInsufficientPrivileges({
-        action: 'patch an auth token',
+        action: 'delete an auth token',
       }));
     }
 
@@ -38,7 +38,7 @@ module.exports = ({authRepository, realtimeConnectionRepository}) =>
       authRepository.deleteOne(query),
       realtimeConnectionRepository.deleteMany({
         realmId,
-        authId: authToDelete.id
+        authId: id
       })
     ]);
 

--- a/src/tasks/client/delete-auth.spec.js
+++ b/src/tasks/client/delete-auth.spec.js
@@ -13,7 +13,7 @@ describe('The client deleteAuth task', () => {
   beforeEach(() => {
     authRepository.findOneAndDelete = jest.fn();
     authRepository.deleteOne = jest.fn();
-    realtimeConnectionRepository.deleteMany = jest.fn();
+    realtimeConnectionRepository.deleteAllByAuthId = jest.fn();
 
     deleteAuth = initDeleteAuth({authRepository, realtimeConnectionRepository});
   });
@@ -44,7 +44,7 @@ describe('The client deleteAuth task', () => {
 
       expect(ok).toBe(true);
       expect(authRepository.deleteOne).toHaveBeenCalled();
-      expect(realtimeConnectionRepository.deleteMany).toHaveBeenCalledWith({
+      expect(realtimeConnectionRepository.deleteAllByAuthId).toHaveBeenCalledWith({
         realmId: authToken.realmId,
         authId: authRepository.knownAuthId,
       })

--- a/src/tasks/client/delete-auth.spec.js
+++ b/src/tasks/client/delete-auth.spec.js
@@ -1,4 +1,5 @@
 const authRepository = require('../../lib/test/mocks/repositories/auth');
+const realtimeConnectionRepository = require('../../lib/test/mocks/repositories/realtime-connection');
 const initDeleteAuth = require('./delete-auth');
 
 describe('The client deleteAuth task', () => {
@@ -11,7 +12,10 @@ describe('The client deleteAuth task', () => {
 
   beforeEach(() => {
     authRepository.findOneAndDelete = jest.fn();
-    deleteAuth = initDeleteAuth({authRepository});
+    authRepository.deleteOne = jest.fn();
+    realtimeConnectionRepository.deleteMany = jest.fn();
+
+    deleteAuth = initDeleteAuth({authRepository, realtimeConnectionRepository});
   });
 
   describe('when called with non-admin scope', () => {
@@ -39,7 +43,11 @@ describe('The client deleteAuth task', () => {
       const {ok} = await deleteAuth({authToken, id: authRepository.knownAuthId});
 
       expect(ok).toBe(true);
-      expect(authRepository.findOneAndDelete).toHaveBeenCalled();
+      expect(authRepository.deleteOne).toHaveBeenCalled();
+      expect(realtimeConnectionRepository.deleteMany).toHaveBeenCalledWith({
+        realmId: authToken.realmId,
+        authId: authRepository.knownAuthId,
+      })
     });
   });
 });

--- a/src/tasks/client/delete-user.js
+++ b/src/tasks/client/delete-user.js
@@ -5,10 +5,16 @@ const taskError = require('../../lib/error/task');
  * Init delete user task.
  * @param {UserRepository} userRepository The user repository
  * @param {AuthRepository} authRepository The auth repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository The realtime connection repository
  * @param {SubscriptionRepository} subscriptionRepository The subscription repository
  * @returns {ClientTasks#deleteUser} Task
  */
-module.exports = ({userRepository, authRepository, subscriptionRepository}) =>
+module.exports = ({
+  userRepository,
+  authRepository,
+  subscriptionRepository,
+  realtimeConnectionRepository
+}) =>
   /**
    * Delete a user and its auth tokens and subscriptions.
    * @function ClientTasks#deleteUser
@@ -38,6 +44,7 @@ module.exports = ({userRepository, authRepository, subscriptionRepository}) =>
       userRepository.findOneAndDelete({realmId, id}),
       authRepository.deleteAllByUserId({realmId, userId: id}),
       subscriptionRepository.deleteAllByUserId({realmId, userId: id}),
+      realtimeConnectionRepository.deleteAllByUserId({realmId, userId: id})
     ]);
 
     return success(user);

--- a/src/tasks/client/delete-user.spec.js
+++ b/src/tasks/client/delete-user.spec.js
@@ -1,5 +1,6 @@
 const userRepository = require('../../lib/test/mocks/repositories/user');
 const authRepository = require('../../lib/test/mocks/repositories/auth');
+const realtimeConnectionRepository = require('../../lib/test/mocks/repositories/realtime-connection');
 const subscriptionRepository = require('../../lib/test/mocks/repositories/subscription');
 const initDeleteUser = require('./delete-user');
 
@@ -14,7 +15,13 @@ describe('The client deleteUser task', () => {
     userRepository.findOneAndDelete = jest.fn();
     authRepository.deleteAllByUserId = jest.fn();
     subscriptionRepository.deleteAllByUserId = jest.fn();
-    deleteUser = initDeleteUser({userRepository, authRepository, subscriptionRepository});
+    realtimeConnectionRepository.deleteAllByUserId = jest.fn();
+    deleteUser = initDeleteUser({
+      userRepository,
+      authRepository,
+      subscriptionRepository,
+      realtimeConnectionRepository
+    });
   });
 
   describe('when called with non-admin scope', () => {
@@ -51,6 +58,7 @@ describe('The client deleteUser task', () => {
       expect(userRepository.findOneAndDelete).toHaveBeenCalled();
       expect(authRepository.deleteAllByUserId).toHaveBeenCalled();
       expect(subscriptionRepository.deleteAllByUserId).toHaveBeenCalled();
+      expect(realtimeConnectionRepository.deleteAllByUserId).toHaveBeenCalled();
     });
   });
 });

--- a/src/tasks/client/index.js
+++ b/src/tasks/client/index.js
@@ -29,7 +29,8 @@ const initPatchUser = require('./patch-user');
  * @param {AuthRepository} authRepository Auth repository
  * @param {ChannelRepository} channelRepository Auth repository
  * @param {MessageRepository} messageRepository Message repository
- * @param {SubscriptionRepository} subscriptionRepository Auth repository
+ * @param {RealtimeConnectionRepository} realtimeConnectionRepository realtime connection repository
+ * @param {SubscriptionRepository} subscriptionRepository Subscription repository
  * @param {UserRepository} userRepository Auth repository
  * @param {CommonTasks#sendSubscriptionSync} sendSubscriptionSync Send subscription created task
  * @return {ClientTasks} Initialized tasks
@@ -39,6 +40,7 @@ module.exports = ({
   authRepository,
   channelRepository,
   messageRepository,
+  realtimeConnectionRepository,
   subscriptionRepository,
   userRepository,
   sendSubscriptionSyncMessage,
@@ -59,7 +61,7 @@ module.exports = ({
   createUser:
     initCreateUser({userRepository}),
   deleteAuth:
-    initDeleteAuth({authRepository}),
+    initDeleteAuth({authRepository, realtimeConnectionRepository}),
   deleteChannel:
     initDeleteChannel({channelRepository, subscriptionRepository}),
   deleteSubscription:

--- a/src/tasks/client/index.js
+++ b/src/tasks/client/index.js
@@ -67,7 +67,12 @@ module.exports = ({
   deleteSubscription:
     initDeleteSubscription({subscriptionRepository, sendSubscriptionSyncMessage}),
   deleteUser:
-    initDeleteUser({userRepository, authRepository, subscriptionRepository}),
+    initDeleteUser({
+      userRepository,
+      authRepository,
+      subscriptionRepository,
+      realtimeConnectionRepository
+    }),
   fetchAuth:
     initFetchAuth({authRepository}),
   fetchChannel:


### PR DESCRIPTION
Introduce client id postfix to support for multiple connections per auth token.

**SDK updates**
- [node-sdk](https://github.com/realmq/realmq-node-sdk/pull/6)
- [web-sdk](https://github.com/realmq/realmq-web-sdk/pull/7)

**TODO**
- [x] Cleanup connections when user gets deleted
- [x] Cleanup connections when auth token gets deleted
- [x] Sync `isOnline` status of users and auth tokens.