### PR TITLE
Obfuscate api-key passed as get parameter between broker and api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add support for upgraded verneMQ broker. This requires the acceptance of their [EULA](https://vernemq.com/end-user-license-agreement/),
   by setting the environment variable `VERNEMQ_ACCEPT_EULA` needs to be set to `yes`.
 
+### Security
+- Obfuscate sensitive information from api request logs.
+
 ## [0.2.0] - 2023-03-09
 
 ### Added

--- a/src/bootstrap/http/server.js
+++ b/src/bootstrap/http/server.js
@@ -15,9 +15,31 @@ module.exports = ({logger}) => {
   http.use(jsonBodyParser());
   http.use(cors());
   http.use((req, res, next) => {
-    logger.info(`HTTP: ${req.method} ${req.originalUrl}`);
+    logHttpRequest({ logger, req });
     next();
   });
 
   return http;
 };
+
+/**
+ * Safely log http requests.
+ *
+ * @param {Object} logger
+ * @param {Object} req
+ */
+function logHttpRequest({ logger, req }) {
+  const url = obfuscateUrl(req.originalUrl);
+
+  logger.info(`HTTP: ${req.method} ${url}`);
+}
+
+/**
+ * Obfuscate any secrets like api-keys passed via get parameter.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+function obfuscateUrl(url) {
+  return url.replace(/(api-key)(:|=)([^&\n]+)/, '$1$2***');
+}


### PR DESCRIPTION
Currently our http request logger dumps all http get parameters.

This PR obfuscates the api-key from logged urls to avoid unwanted leak of sensitive information.