### PR TITLE
Add support for upgraded broker that requires VerneMQ EULA acceptance.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,5 +2,6 @@
 
 COMPOSE_PROJECT_NAME=realmq
 PORT=8080
-
 API_ADMIN_KEY=put-your-admin-key-here
+# Make sure you read and accept https://vernemq.com/end-user-license-agreement/
+VERNEMQ_ACCEPT_EULA=yes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+- Add support for upgraded verneMQ broker. This requires the acceptance of their [EULA](https://vernemq.com/end-user-license-agreement/),
+  by setting the environment variable `VERNEMQ_ACCEPT_EULA` needs to be set to `yes`.
+
 ## [0.2.0] - 2023-03-09
 
 ### Added

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
       - ADAPTER_HOST=platform
       - ADAPTER_PORT=${PORT:-8080}
       - CREDENTIALS=adapter:adapter
+      - VERNEMQ_ACCEPT_EULA=${VERNEMQ_ACCEPT_EULA:-no}
 
   certificates:
     image: realmq/dev-ca

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -3,15 +3,16 @@
 The app is aware of the following environment variables,
 that can also be injected via `.env` file:
 
-| Variable        | Description                                          | Default                                         |
-|-----------------|------------------------------------------------------|-------------------------------------------------|
-| LOG_LEVEL       | App wide logging verbosity                           | `info`                                          |
-| PORT            | The HTTP Port the server will listen to              | `8080`                                          |
-| DB_URL          | MongoDB connection url                               | `mongodb://realmq:realmq@database:27017/realmq` |
-| API_ADMIN_KEY   | Fixed api key used to authenticate against admin api | _empty_                                         |
-| API_BROKER_KEY  | Key for securing broker -> platform communication    | _empty_                                         |
-| BROKER_PROTOCOL | Protocol used for platform -> broker connection      | `mqtt`                                          |
-| BROKER_HOST     | Host used for platform -> broker connection          | `broker`                                        |
-| BROKER_PORT     | Port used for platform -> broker connection          | `1883`                                          |
-| BROKER_USERNAME | Username used for platform -> broker connection      | `adapter`                                       |
-| BROKER_PASSWORD | Password used for platform -> broker connection      | `adapter`                                       |
+| Variable            | Description                                                                  | Default                                         |
+|---------------------|------------------------------------------------------------------------------|-------------------------------------------------|
+| LOG_LEVEL           | App wide logging verbosity                                                   | `info`                                          |
+| PORT                | The HTTP Port the server will listen to                                      | `8080`                                          |
+| DB_URL              | MongoDB connection url                                                       | `mongodb://realmq:realmq@database:27017/realmq` |
+| API_ADMIN_KEY       | Fixed api key used to authenticate against admin api                         | _empty_                                         |
+| API_BROKER_KEY      | Key for securing broker -> platform communication                            | _empty_                                         |
+| BROKER_PROTOCOL     | Protocol used for platform -> broker connection                              | `mqtt`                                          |
+| BROKER_HOST         | Host used for platform -> broker connection                                  | `broker`                                        |
+| BROKER_PORT         | Port used for platform -> broker connection                                  | `1883`                                          |
+| BROKER_USERNAME     | Username used for platform -> broker connection                              | `adapter`                                       |
+| BROKER_PASSWORD     | Password used for platform -> broker connection                              | `adapter`                                       |
+| VERNEMQ_ACCEPT_EULA | In order to use the bundled verneMQ broker, you need to accept their licence | `no`                                            |


### PR DESCRIPTION
In order to support the broker upgrade, we need to allow for setting the `VERNEMQ_ACCEPT_EULA` environment variable.

This PR solves the issue.