### PR TITLE
Sign CI config file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 workspace:
   base: /platform
 
@@ -80,3 +81,8 @@ pipeline:
     repo: realmq/realmq-platform
     secrets: [docker_username, docker_password]
     auto_tag: true
+---
+kind: signature
+hmac: a9dc223207ebec48b211f47d11708b3bbf987a3a4a37347f185db0c3e1b5d456
+
+...


### PR DESCRIPTION
In the current settings the CI server requires the config file to be signed to automatically run a build. If the config file is not signed or the signature does not match every build needs to be manually approved. This PR signs the current config file.

Command used to sign:
```
$ DRONE_SERVER=https://drone.rmq.ovh DRONE_TOKEN=*REDACTED* drone sign --save realmq/realmq-platform
```