### PR TITLE
#139: Update "Getting started" section in client API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add support for upgraded verneMQ broker. This requires the acceptance of their [EULA](https://vernemq.com/end-user-license-agreement/),
   by setting the environment variable `VERNEMQ_ACCEPT_EULA` needs to be set to `yes`.
 - **BREAKING**: Secret `auth.token` is removed from list, detail & update responses of `/client/v1/auths/*`. ([#138])
+- Updated "Getting started" section in client API documentation ([#139]).
+
+[#139]: https://github.com/realmq/realmq-platform/issues/139
 
 ### Security
 - Obfuscate sensitive information from api request logs.

--- a/src/api/client/v1/openapi.yaml
+++ b/src/api/client/v1/openapi.yaml
@@ -6,8 +6,10 @@ info:
   description: |
     ## Getting Started
 
-    * Get in touch with us to get an account set up. You can do that by sending an email to <a href="mailto:service@realmq.com">service@realmq.com</a>
-    * We'll provide you with an `accessToken` with admin scope that allows you to create further users and access tokens.
+    * Create an account on [cloud.realmq.com](https://cloud.realmq.com).
+    * Open the _test_ project and navigate to the _Tokens_ section.
+    * Create a new token with the _admin_ scope.
+    * Copy the token and store it securely (it's not accessible after initial display)
     * Paste the `accessToken` into the access token input field in the header of the api browser.
     * There are two access groups (**scopes**). Every API endpoint has a description of what scopes are allowed to perform requests.
       - **admin** Full management capabilities, administration capabilities

--- a/src/api/client/v1/openapi.yaml
+++ b/src/api/client/v1/openapi.yaml
@@ -24,7 +24,7 @@ info:
 
     ## Custom Ids
 
-    * In order to provide optimal integratability, you can work with custom ids on channels, users, subscriptions and auth-tokens.
+    * In order to provide optimal integrability, you can work with custom ids on channels, users, subscriptions and auth-tokens.
     * When creating these resources, you can pass an `id` property to the payload.
     * You can then reference the resource by its custom id: eg. `GET /users/test-bot-1`.
     * Valid ids must match `^[\w-]+$` (**alpha-numeric**, **-**, **_**).


### PR DESCRIPTION
This PRs updates the "Getting started" section in client API documentation to reference the new cloud service.

This is part of #139.